### PR TITLE
List entries on homepage

### DIFF
--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -1,8 +1,24 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { getAllEntriesThunk, getEntryCountThunk } from '../store'
+import {
+  getAllEntriesThunk,
+  getEntryCountThunk,
+  getAllMyPromptsThunk
+} from '../store'
 import { Link } from 'react-router-dom'
+
+// Material UI
+import { makeStyles } from '@material-ui/core/styles'
+import Card from '@material-ui/core/Card'
+import CardContent from '@material-ui/core/CardContent'
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: 275,
+    margin: '2em'
+  }
+})
 
 /**
  * COMPONENT
@@ -14,28 +30,34 @@ export const Home = (props) => {
     entries,
     entryCount,
     getEntryCount,
-    getAllEntries
+    getAllEntries,
+    getPrompts,
+    prompts
   } = props
 
   useEffect(() => {
     getEntryCount(userId)
     getAllEntries(userId)
+    getPrompts(userId)
   }, [])
+
+  const classes = useStyles()
 
   return (
     <div>
       <h3>Welcome, {userFirstName}</h3>
       <p>You have {entryCount} entries. </p>
-      <ul>
-        {entries &&
-          entries.map((e) => (
-            <li>
-              <Link key={e.id} to={`/entry/${e.id}`}>
+      {entries &&
+        entries.map((e) => (
+          <Card key={e.id} className={classes.root}>
+            <CardContent>
+              <Link to={`/entry/${e.id}`}>
+                {prompts[e.promptId] && prompts[e.promptId].subject}{' '}
                 {e.updatedAt}
               </Link>
-            </li>
-          ))}
-      </ul>
+            </CardContent>
+          </Card>
+        ))}
     </div>
   )
 }
@@ -49,7 +71,8 @@ const mapState = (state) => {
     userFirstName: state.user.me.firstName,
     entries: state.entry.all,
     entryCount: state.entry.count,
-    email: state.user.me.email
+    email: state.user.me.email,
+    prompts: state.prompt.all
   }
 }
 
@@ -57,6 +80,9 @@ const mapDispatch = (dispatch) => {
   return {
     getEntryCount(userId) {
       dispatch(getEntryCountThunk(userId))
+    },
+    getPrompts(userId) {
+      dispatch(getAllMyPromptsThunk(userId))
     },
     getAllEntries(userId) {
       dispatch(getAllEntriesThunk(userId))

--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -1,22 +1,41 @@
-import React, {useEffect, useState} from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import {connect} from 'react-redux'
-import {getEntryCountThunk} from '../store'
+import { connect } from 'react-redux'
+import { getAllEntriesThunk, getEntryCountThunk } from '../store'
+import { Link } from 'react-router-dom'
 
 /**
  * COMPONENT
  */
 export const Home = (props) => {
-  const {userId, entryCount, userFirstName, getEntryCount} = props
+  const {
+    userId,
+    userFirstName,
+    entries,
+    entryCount,
+    getEntryCount,
+    getAllEntries
+  } = props
 
   useEffect(() => {
     getEntryCount(userId)
+    getAllEntries(userId)
   }, [])
 
   return (
     <div>
       <h3>Welcome, {userFirstName}</h3>
       <p>You have {entryCount} entries. </p>
+      <ul>
+        {entries &&
+          entries.map((e) => (
+            <li>
+              <Link key={e.id} to={`/entry/${e.id}`}>
+                {e.updatedAt}
+              </Link>
+            </li>
+          ))}
+      </ul>
     </div>
   )
 }
@@ -28,6 +47,7 @@ const mapState = (state) => {
   return {
     userId: state.user.me.id,
     userFirstName: state.user.me.firstName,
+    entries: state.entry.all,
     entryCount: state.entry.count,
     email: state.user.me.email
   }
@@ -37,6 +57,9 @@ const mapDispatch = (dispatch) => {
   return {
     getEntryCount(userId) {
       dispatch(getEntryCountThunk(userId))
+    },
+    getAllEntries(userId) {
+      dispatch(getAllEntriesThunk(userId))
     }
   }
 }

--- a/client/store/entry.js
+++ b/client/store/entry.js
@@ -1,109 +1,114 @@
-import axios from 'axios';
+import axios from 'axios'
+import moment from 'moment'
 
 /**
  * ACTION TYPES
  */
-const GET_ALL_ENTRIES = 'GET_ALL_ENTRIES';
-const GET_SINGLE_ENTRY = 'GET_SINGLE_ENTRY';
-const GET_ENTRY_COUNT = 'GET_ENTRY_COUNT';
-const ADD_ENTRY = 'ADD_ENTRY';
-const UPDATE_ENTRY = 'UPDATE_ENTRY';
-const REMOVE_ENTRY = 'REMOVE_ENTRY';
+const GET_ALL_ENTRIES = 'GET_ALL_ENTRIES'
+const GET_SINGLE_ENTRY = 'GET_SINGLE_ENTRY'
+const GET_ENTRY_COUNT = 'GET_ENTRY_COUNT'
+const ADD_ENTRY = 'ADD_ENTRY'
+const UPDATE_ENTRY = 'UPDATE_ENTRY'
+const REMOVE_ENTRY = 'REMOVE_ENTRY'
 
 /**
  * ACTION CREATORS
  */
-const getAllEntries = (entries) => ({ type: GET_ALL_ENTRIES, entries });
-const getSingleEntry = (entry) => ({ type: GET_SINGLE_ENTRY, entry });
-const getEntryCount = (count) => ({ type: GET_ENTRY_COUNT, count });
-const addEntry = (entry) => ({ type: ADD_ENTRY, entry });
-const updateEntry = (entry) => ({ type: UPDATE_ENTRY, entry });
-const removeEntry = (entryId) => ({ type: REMOVE_ENTRY, entryId });
+const getAllEntries = (entries) => ({ type: GET_ALL_ENTRIES, entries })
+const getSingleEntry = (entry) => ({ type: GET_SINGLE_ENTRY, entry })
+const getEntryCount = (count) => ({ type: GET_ENTRY_COUNT, count })
+const addEntry = (entry) => ({ type: ADD_ENTRY, entry })
+const updateEntry = (entry) => ({ type: UPDATE_ENTRY, entry })
+const removeEntry = (entryId) => ({ type: REMOVE_ENTRY, entryId })
 
 /**
  * THUNK CREATORS
  */
 
-export const getAllEntriesThunk = userId => {
+export const getAllEntriesThunk = (userId) => {
   return async (dispatch) => {
     try {
-      const { data } = await axios.get(`/api/entries/user/${userId}`);
-      dispatch(getAllEntries(data));
+      const { data } = await axios.get(`/api/entries/user/${userId}`)
+      const formattedData = data.map((en) => {
+        en.updatedAt = moment(en.updatedAt).format('MMMM DD, YYYY')
+        return en
+      })
+      dispatch(getAllEntries(data))
     } catch (err) {
-      console.error(err.message);
+      console.error(err.message)
     }
-  };
-};
+  }
+}
 
 export const getSingleEntryThunk = (userId, entryId) => {
   return async (dispatch) => {
     try {
       const { data } = await axios.get(
         `/api/entries/user/${userId}/entry/${entryId}`
-      );
-      dispatch(getSingleEntry(data));
+      )
+      dispatch(getSingleEntry(data))
     } catch (err) {
-      console.error(err.message);
+      console.error(err.message)
     }
-  };
-};
+  }
+}
 
 export const getEntryCountThunk = (userId) => {
   return async (dispatch) => {
     try {
       const { data } = await axios.get(
         `/api/entries/user/${userId}/count/entries`
-      );
-      dispatch(getEntryCount(data));
+      )
+      dispatch(getEntryCount(data))
     } catch (err) {
-      console.error(err.message);
+      console.error(err.message)
     }
-  };
-};
+  }
+}
 
 export const addEntryThunk = (entry) => {
   return async (dispatch) => {
     try {
-      const { data } = await axios.post('/api/entries', entry);
-      dispatch(addEntry(data));
+      const { data } = await axios.post('/api/entries', entry)
+      dispatch(addEntry(data))
     } catch (err) {
-      console.error(err.message);
+      console.error(err.message)
     }
-  };
-};
+  }
+}
 
 export const updateEntryThunk = (userId, entryId, entryUpdates) => {
   return async (dispatch) => {
     try {
-      let { entriesubject } = entryUpdates;
+      let { entriesubject } = entryUpdates
 
       let putObject = {
         id: entryId,
-        subject: entriesubject,
-      };
+        subject: entriesubject
+      }
 
       const { data } = await axios.put(
         `/api/entries/user/${userId}/entry/${entryId}`,
         putObject
-      );
+      )
 
-      dispatch(updateEntry(data));
+      dispatch(updateEntry(data))
     } catch (err) {
-      console.error(err.message);
+      console.error(err.message)
     }
-  };
-};
+  }
+}
 
 export const removeEntryThunk = (userId, entryId) => {
   return async (dispatch) => {
     try {
-      await axios.delete(`/api/entries/user/${userId}/entry/${entryId}`);
-      dispatch(removeEntry(entryId));
+      await axios.delete(`/api/entries/user/${userId}/entry/${entryId}`)
+      dispatch(removeEntry(entryId))
     } catch (err) {
-      console.error(err.message);
+      console.error(err.message)
     }
-  };
-};
+  }
+}
 
 /**
  * INITIAL STATE
@@ -111,8 +116,8 @@ export const removeEntryThunk = (userId, entryId) => {
 const initialState = {
   all: [],
   single: {},
-  count: 0,
-};
+  count: 0
+}
 
 /**
  * REDUCER
@@ -120,29 +125,29 @@ const initialState = {
 export default function (state = initialState, action) {
   switch (action.type) {
     case GET_ALL_ENTRIES:
-      return { ...state, all: action.entries };
+      return { ...state, all: action.entries }
     case GET_SINGLE_ENTRY:
-      return { ...state, single: action.entry };
+      return { ...state, single: action.entry }
     case GET_ENTRY_COUNT:
-      return { ...state, count: action.count };
+      return { ...state, count: action.count }
     case ADD_ENTRY:
-      return { ...state, all: [...state.all, action.entry] };
+      return { ...state, all: [...state.all, action.entry] }
     case UPDATE_ENTRY:
       return {
         ...state,
         single: action.entry,
         all: state.all.map((entry) => {
-          if (entry.id === action.entry.id) entry = action.entry;
-          return entry;
-        }),
-      };
+          if (entry.id === action.entry.id) entry = action.entry
+          return entry
+        })
+      }
     case REMOVE_ENTRY:
       return {
         ...state,
-        all: state.all.filter((entry) => entry.id !== action.entryId),
-      };
+        all: state.all.filter((entry) => entry.id !== action.entryId)
+      }
 
     default:
-      return state;
+      return state
   }
 }

--- a/client/store/entry.js
+++ b/client/store/entry.js
@@ -24,10 +24,10 @@ const removeEntry = (entryId) => ({ type: REMOVE_ENTRY, entryId });
  * THUNK CREATORS
  */
 
-export const getAllEntriesThunk = () => {
+export const getAllEntriesThunk = userId => {
   return async (dispatch) => {
     try {
-      const { data } = await axios.get('/api/entries');
+      const { data } = await axios.get(`/api/entries/user/${userId}`);
       dispatch(getAllEntries(data));
     } catch (err) {
       console.error(err.message);

--- a/client/store/prompt.js
+++ b/client/store/prompt.js
@@ -33,10 +33,23 @@ export const getAllPromptsThunk = () => {
   }
 }
 
+// gets only the prompts that a single user has already responded to.
+// in a future where we might not want a user to load every single prompt
+export const getAllMyPromptsThunk = (userId) => {
+  return async (dispatch) => {
+    try {
+      const { data } = await axios.get(`/api/prompts/user/${userId}`)
+      dispatch(getAllPrompts(data))
+    } catch (err) {
+      console.error(err.message)
+    }
+  }
+}
+
 export const getSinglePromptThunk = (promptId) => {
   return async (dispatch) => {
     try {
-      const { data } = await axios.get(`/api/prompts/${promptId}`)
+      const { data } = await axios.get(`/api/prompts/id/${promptId}`)
       dispatch(getSinglePrompt(data))
     } catch (err) {
       console.error(err.message)

--- a/client/store/prompt.js
+++ b/client/store/prompt.js
@@ -26,7 +26,10 @@ export const getAllPromptsThunk = () => {
   return async (dispatch) => {
     try {
       const { data } = await axios.get('/api/prompts')
-      dispatch(getAllPrompts(data))
+      const normalizedData = data.reduce((ac, cu) => {
+        ac[cu.id] = cu
+        return ac
+      }, {})
     } catch (err) {
       console.error(err.message)
     }
@@ -39,7 +42,11 @@ export const getAllMyPromptsThunk = (userId) => {
   return async (dispatch) => {
     try {
       const { data } = await axios.get(`/api/prompts/user/${userId}`)
-      dispatch(getAllPrompts(data))
+      const normalizedData = data.reduce((ac, cu) => {
+        ac[cu.id] = cu
+        return ac
+      }, {})
+      dispatch(getAllPrompts(normalizedData))
     } catch (err) {
       console.error(err.message)
     }
@@ -102,7 +109,7 @@ export const removePromptThunk = (promptId) => {
  * INITIAL STATE
  */
 const initialState = {
-  all: [],
+  all: {},
   single: {}
 }
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "express": "^4.16.4",
     "express-session": "^1.15.1",
     "history": "^4.9.0",
+    "moment": "^2.29.1",
     "morgan": "^1.9.1",
     "passport": "^0.4.0",
     "passport-google-oauth": "^2.0.0",

--- a/script/seed.js
+++ b/script/seed.js
@@ -24,6 +24,7 @@ async function seed() {
 
   const prompts = await Promise.all([
     Prompt.create({ subject: 'Why?' }),
+    Prompt.create({ subject: 'Who?' }),
     Prompt.create({ subject: 'How?' })
   ])
 

--- a/server/api/entries.js
+++ b/server/api/entries.js
@@ -5,12 +5,12 @@ const { userIsSelfMiddleware } = require('../middleware')
 
 router.get('/user/:userId/', userIsSelfMiddleware, async (req, res, next) => {
   try {
-    const entry = await Entry.findAll({
+    const entries = await Entry.findAll({
       where: {
         userId: req.params.userId
       }
     })
-    entry ? res.json(entry) : res.status(400).end()
+    res.json(entries)
   } catch (err) {
     next(err)
   }

--- a/server/api/prompts.js
+++ b/server/api/prompts.js
@@ -1,21 +1,43 @@
 const router = require('express').Router()
-const { Prompt } = require('../db/models')
+const { Op } = require("sequelize");
+const { Prompt, Entry } = require('../db/models')
 
 module.exports = router
 
 router.get('/', async (req, res, next) => {
   try {
     const prompts = await Prompt.findAll()
-    prompts ? res.json(prompts) : res.status(400).end()
+    res.json(prompts)
   } catch (err) {
     next(err)
   }
 })
 
-router.get('/:promptId', async (req, res, next) => {
+router.get('/user/:userId', async (req, res, next) => {
+  try {
+    const userEntries = await Entry.findAll({
+      where: {
+        userId: req.params.userId
+      }
+    })
+    const promptIdList = userEntries.map((en) => ({
+      id: en.promptId
+    }))
+    const prompts = await Prompt.findAll({
+      where: {
+        [Op.or]: promptIdList
+      }
+    })
+    res.json(prompts)
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.get('/id/:promptId', async (req, res, next) => {
   try {
     const prompt = await Prompt.findByPk(req.params.promptId)
-    prompt ? res.json(prompt) : res.status(400).end()
+    res.json(prompt)
   } catch (err) {
     next(err)
   }


### PR DESCRIPTION
* installs moment
* updates seed file
* new route: get only prompts that a user has already answered
* adds entry info to homepage as a list

in the future I anticipate maybe not listing every entry on the homepage. maybe grouping by month or list of prompts?

`npm install` needed after merge.